### PR TITLE
特定の箇所のエラーではエラーコードのみを返すようにする

### DIFF
--- a/lib/Api/FinancesV0Api.php
+++ b/lib/Api/FinancesV0Api.php
@@ -491,6 +491,7 @@ class FinancesV0Api extends BaseApi
                 $body = (string) ($hasResponse ? $e->getResponse()->getBody() : '[NULL response]');
                 $this->writeDebug($e->getResponse());
                 $this->writeDebug($body);
+                return $e->getCode();
                 throw new ApiException(
                     "[{$e->getCode()}] {$body}",
                     $e->getCode(),

--- a/lib/Api/ProductPricingV0Api.php
+++ b/lib/Api/ProductPricingV0Api.php
@@ -533,6 +533,7 @@ class ProductPricingV0Api extends BaseApi
                 $body = (string) ($hasResponse ? $e->getResponse()->getBody() : '[NULL response]');
                 $this->writeDebug($e->getResponse());
                 $this->writeDebug($body);
+                return $e->getCode();
                 throw new ApiException(
                     "[{$e->getCode()}] {$body}",
                     $e->getCode(),


### PR DESCRIPTION
QuotaExceededでは処理を止めず、継続したいのでエラーコードを返し、再試行するようにする。